### PR TITLE
Removing reference to `hello@opentracing.com` - unknown user

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is by no means an exhaustive list, but what follows is an incomplete list o
 
 # Conference Speaking Opportunities
 
-We like to spread the word about OpenTracing at conferences. We're always excited to collaborate with anyone who'd like to help out. If that sounds like you, please drop us a note at [hello@opentracing.com](mailto:hello@opentracing.com). Specifically we are looking for:
+We like to spread the word about OpenTracing at conferences. We're always excited to collaborate with anyone who'd like to help out. If that sounds like you, please reach out via the [mailing list](https://groups.google.com/forum/#!forum/opentracing) or [Gitter](https://gitter.im/opentracing/public). Specifically we are looking for:
 
 1. Co-presenting opportunities around OpenTracing, including workshops like the ones we've run at Kubecon/OSCON/etc
 2. Advice if you have spoken at these events or are involved with the committee


### PR DESCRIPTION
Sending an email to `hello@opentracing.com` (referenced in the README) results in an error. I've replaced this with a reference to the mailing list and Gitter.

```
This is the mail system at host eforward1a.registrar-servers.com.

I'm sorry to have to inform you that your message could not
be delivered to one or more recipients. It's attached below.

For further assistance, please send mail to postmaster.

If you do so, please include this problem report. You can
delete your own text from the attached returned message.

                   The mail system

<hello@opentracing.com>: unknown user: "hello@opentracing.com"
```