### PR TITLE
Typo: Sprint boot -> Spring boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The following are known OpenTracing-compatible projects. Create a PR for any pro
 **Other Projects**
 * [java-api-extensions](https://github.com/opentracing-contrib/java-api-extensions) - OpenTracing API extensions
 * [java-cdi](https://github.com/opentracing-contrib/java-cdi) - Java EE CDI
-* [java-spring-tracer-configuration](https://github.com/opentracing-contrib/java-spring-tracer-configuration) - Sprint Boot auto-configuration
+* [java-spring-tracer-configuration](https://github.com/opentracing-contrib/java-spring-tracer-configuration) - Spring Boot auto-configuration
 * [java-tracerresolver](https://github.com/opentracing-contrib/java-tracerresolver) - Spring Boot resolver
 
 ## [JavaScript](https://github.com/opentracing/opentracing-javascript)


### PR DESCRIPTION
Sprint boot should be Spring boot