### PR TITLE
Add entry for opentracing-sqs-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The following are known OpenTracing-compatible projects. Create a PR for any pro
 * [opentracing-jdbc](https://github.com/lucidsoftware/opentracing-jdbc) - JDBC
 * [opentracing-metrics](https://github.com/opentracing-contrib/java-metrics) - Micrometer and Prometheus metrics
 * [opentracing-playframework](https://github.com/lucidsoftware/opentracing-playframework) - Play framework
+* [opentracing-sqs-java](https://github.com/zalando-incubator/opentracing-sqs-java) - Amazon SQS
 * [perfevents](https://github.com/opentracing-contrib/perfevents/java) - Linux perfevents
 * [scala-akka](https://github.com/opentracing-contrib/scala-akka) - Scala Akka
 * [scala-concurrent](https://github.com/opentracing-contrib/scala-concurrent) - scala.concurrent


### PR DESCRIPTION
Hi,

I've created a small Java helper library for transporting span contexts across Amazon SQS. This includes it to the list of Java libraries.